### PR TITLE
Fixing IndexError on CWE-749.py

### DIFF
--- a/CWE-749/CWE-749.py
+++ b/CWE-749/CWE-749.py
@@ -17,8 +17,11 @@ for configureJsExecution in quarkResult.behaviorOccurList:
     caller = configureJsExecution.methodCaller
     secondAPI = configureJsExecution.secondAPI
 
-    enableJS = secondAPI.getArguments()[1]
-    exposeAPI = quarkResult.findMethodInCaller(caller, targetMethod)
+    # Check if arguments list has at least two elements
+    arguments = secondAPI.getArguments()
+    if len(arguments) >= 2:
+        enableJS = arguments[1]
+        exposeAPI = quarkResult.findMethodInCaller(caller, targetMethod)
 
-    if enableJS and exposeAPI:
-        print(f"CWE-749 is detected in method, {caller.fullName}")
+        if enableJS and exposeAPI:
+            print(f"CWE-749 is detected in method, {caller.fullName}")


### PR DESCRIPTION
So by adding the `if len(arguments) >= 2` check, you ensure that the code inside the loop is only executed when the `getArguments() ` list has at least two elements, avoiding the "list index out of range" error.

![image](https://github.com/quark-engine/quark-script/assets/84577967/214c576d-843f-4900-82b2-19fcc7b9f691)

