### PR TITLE
Optimize the document of Quark Script CWE-73 and 78

### DIFF
--- a/CWE-73/CWE-73.py
+++ b/CWE-73/CWE-73.py
@@ -1,7 +1,7 @@
 from quark.script import runQuarkAnalysis, Rule
 
 SAMPLE_PATH = "ovaa.apk"
-RULE_PATH = "accessFileInExternalDir.json"
+RULE_PATH = "useLastPathSegmentAsFileName.json"
 
 OPEN_FILE_API = [
     "Landroid/os/ParcelFileDescriptor;",                   # Class name

--- a/CWE-73/README.md
+++ b/CWE-73/README.md
@@ -1,48 +1,42 @@
-# Detect CWE-73 in Android Application
+# Detect CWE-73 in Android Application 
 
-This scenario seeks to find **External Control of File Name or Path** in
-the APK file.
+This scenario seeks to find **External Control of File Name or Path** in the APK file.
 
 ## CWE-73 External Control of File Name or Path
 
 We analyze the definition of CWE-73 and identify its characteristics.
 
-See [CWE-73](https://cwe.mitre.org/data/definitions/73.html) for more
-details.
+See [CWE-73](https://cwe.mitre.org/data/definitions/73.html) for more details.
 
-![image](https://imgur.com/ES7xg5X.png)
+![image](https://imgur.com/I1C5yku.png)
 
 ## Code of CWE-73 in ovaa.apk
 
-We use the [ovaa.apk](https://github.com/oversecured/ovaa) sample to
-explain the vulnerability code of CWE-73.
+We use the [ovaa.apk](https://github.com/oversecured/ovaa) sample to explain the vulnerability code of CWE-73.
 
-![image](https://imgur.com/9oa1HIC.png)
+![image](https://imgur.com/gLJ6zWr.png)
+
+## CWE-73 Detection Process Using Quark Script API
+
+![image](https://imgur.com/zGjZHA1.png)
+
+Let’s use the above APIs to show how Quark script finds this vulnerability.
+
+First, we design a detection rule ``useLastPathSegmentAsFileName.json`` to spot behavior that uses the last path segment as the file name.
+
+Second, we use the API ``methodInstance.getArguments()`` to get the argument for the file path and use ``quarkResultInstance.isHardcoded(argument)`` to check if the argument is hardcoded into the APK. If **No**, the argument is from external input.
+
+Finally, we use Quark API ``quarkResultInstance.findMethodInCaller(callerMethod, targetMethod)`` to check if there are any APIs in the caller method for opening files. If **YES**, the APK performs file operations using external input as a path, which may cause CWE-73 vulnerability.
 
 ## Quark Script: CWE-73.py
 
-Let's use the above APIs to show how Quark script find this
-vulnerability.
+![image](https://imgur.com/EHrcCPg.png)
 
-First, we design a detection rule `accessFileInExternalDir.json` to spot
-behavior accessing a file in an external directory.
-
-Second, we use API `methodInstance.getArguments()` to get the argument
-for the file path and use `quarkResultInstance.isHardcoded(argument)` to
-check if the argument is hardcoded into the APK. If **No**, the argument
-is from external input.
-
-Finally, we use Quark API
-`quarkResultInstance.findMethodInCaller(callerMethod, targetMethod)` to
-check if any APIs in the caller method for opening files. If **YES**,
-the APK performs file operations using external input as a path, which
-may cause CWE-73 vulnerability.
-
-``` python
+```python
 from quark.script import runQuarkAnalysis, Rule
 
 SAMPLE_PATH = "ovaa.apk"
-RULE_PATH = "accessFileInExternalDir.json"
+RULE_PATH = "useLastPathSegmentAsFileName.json"
 
 OPEN_FILE_API = [
     "Landroid/os/ParcelFileDescriptor;",                   # Class name
@@ -66,17 +60,19 @@ for accessExternalDir in quarkResult.behaviorOccurList:
         print("CWE-73 is detected in method, ", caller.fullName)
 ```
 
-## Quark Rule: accessFileInExternalDir.json
+## Quark Rule: useLastPathSegmentAsFileName.json
 
-``` json
+![image](https://imgur.com/JxBdde0.png)
+
+```json
 {
-    "crime": "Access a file in an external directory",
+    "crime": "Use the last path segment as the file name",
     "permission": [],
     "api": [
         {
-            "class": "Landroid/os/Environment;",
-            "method": "getExternalStorageDirectory",
-            "descriptor": "()Ljava/io/File;"
+            "class": "Landroid/net/Uri;",
+            "method": "getLastPathSegment",
+            "descriptor": "()Ljava/lang/String;"
         },
         {
             "class": "Ljava/io/File;",
@@ -91,7 +87,7 @@ for accessExternalDir in quarkResult.behaviorOccurList:
 
 ## Quark Script Result
 
-``` TEXT
+```
 $ python CWE-73.py
 CWE-73 is detected in method, Loversecured/ovaa/providers/TheftOverwriteProvider; openFile (Landroid/net/Uri; Ljava/lang/String;)Landroid/os/ParcelFileDescriptor;
 ```

--- a/CWE-73/useLastPathSegmentAsFileName.json
+++ b/CWE-73/useLastPathSegmentAsFileName.json
@@ -1,11 +1,11 @@
 {
-    "crime": "Access a file in an external directory",
+    "crime": "Use the last path segment as the file name",
     "permission": [],
     "api": [
         {
-            "class": "Landroid/os/Environment;",
-            "method": "getExternalStorageDirectory",
-            "descriptor": "()Ljava/io/File;"
+            "class": "Landroid/net/Uri;",
+            "method": "getLastPathSegment",
+            "descriptor": "()Ljava/lang/String;"
         },
         {
             "class": "Ljava/io/File;",
@@ -16,4 +16,3 @@
     "score": 1,
     "label": []
 }
-

--- a/CWE-78/README.md
+++ b/CWE-78/README.md
@@ -1,42 +1,40 @@
 # Detect CWE-78 in Android Application
 
-This scenario seeks to find **Improper Neutralization of Special
-Elements used in an OS Command** in the APK file.
+This scenario seeks to find **Improper Neutralization of Special Elements used in an OS Command** in the APK file.
 
-## CWE-78 Improper Neutralization of Special Elements used in an OS Command (\'OS Command Injection\')
+## CWE-78 Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
 
 We analyze the definition of CWE-78 and identify its characteristics.
 
-See [CWE-78](https://cwe.mitre.org/data/definitions/78.html) for more
-details.
+See [CWE-78](https://cwe.mitre.org/data/definitions/78.html) for more details.
 
-![image](https://imgur.com/aUB195P.png)
+![image](https://imgur.com/HpMGGsO.png)
 
 ## Code of CWE-78 in Vuldroid.apk
 
-We use the [Vuldroid.apk](https://github.com/jaiswalakshansh/Vuldroid)
-sample to explain the vulnerability code of CWE-78.
+We use the [Vuldroid.apk](https://github.com/jaiswalakshansh/Vuldroid) sample to explain the vulnerability code of CWE-78.
 
-![image](https://imgur.com/hO6m3Bz.png)
+![image](https://imgur.com/7Tu0Y3H.png)
+
+## CWE-78 Detection Process Using Quark Script API
+
+![image](https://imgur.com/Hi7qGjw.png)
+
+Let’s use the above APIs to show how the Quark script finds this vulnerability.
+
+First, we design a detection rule `ExternalStringsCommands.json` to spot on behavior using external strings as commands.
+
+Next, we use Quark API `behaviorInstance.getMethodsInArgs()` to get the methods that passed the external command.
+
+Then we check if the method neutralizes any special elements in the argument.
+
+If the neutralization is not complete, then it may cause CWE-78 vulnerability.
 
 ## Quark Script: CWE-78.py
 
-Let's use the above APIs to show how the Quark script finds this
-vulnerability.
+![image](https://imgur.com/UpRWgGe.png)
 
-First, we design a detection rule `ExternalStringsCommands.json` to spot
-on behavior using external strings as commands.
-
-Next, we use Quark API `behaviorInstance.getMethodsInArgs()` to get the
-methods that passed the external command.
-
-Then we check if the method neutralizes any special elements found in
-the argument.
-
-If the neutralization is not complete, then it may cause CWE-78
-vulnerability.
-
-``` python
+```python
 from quark.script import runQuarkAnalysis, Rule, findMethodInAPK
 
 SAMPLE_PATH = "Vuldroid.apk"
@@ -48,7 +46,11 @@ STRING_MATCHING_API = set([
     ("Ljava/lang/String;", "indexOf", "(I)I"),
     ("Ljava/lang/String;", "indexOf", "(Ljava/lang/String;)I"),
     ("Ljava/lang/String;", "matches", "(Ljava/lang/String;)Z"),
-    ("Ljava/lang/String;", "replaceAll", "(Ljava/lang/String; Ljava/lang/String;)Ljava/lang/String;")
+    (
+        "Ljava/lang/String;",
+        "replaceAll",
+        "(Ljava/lang/String; Ljava/lang/String;)Ljava/lang/String;",
+    ),
 ])
 
 specialElementsPattern = r"[ ;|,>`]+"
@@ -69,10 +71,12 @@ for ExternalStringCommand in quarkResult.behaviorOccurList:
     else:
         print(f"CWE-78 is detected in method, {caller.fullName}")
 ```
-
+        
 ## Quark Rule: ExternalStringCommand.json
 
-``` json
+![image](https://imgur.com/eoV8hnZ.png)
+
+```json
 {
     "crime": "Using external strings as commands",
     "permission": [],
@@ -95,9 +99,7 @@ for ExternalStringCommand in quarkResult.behaviorOccurList:
 
 ## Quark Script Result
 
--   **Vuldroid.apk**
-
-``` TEXT
+```
 $ python3 CWE-78.py
 CWE-78 is detected in method, Lcom/vuldroid/application/RootDetection; onCreate (Landroid/os/Bundle;)V
 ```


### PR DESCRIPTION
# Detect CWE-73 in Android Application 

This scenario seeks to find **External Control of File Name or Path** in the APK file.

## CWE-73 External Control of File Name or Path

We analyze the definition of CWE-73 and identify its characteristics.

See [CWE-73](https://cwe.mitre.org/data/definitions/73.html) for more details.

![image](https://imgur.com/I1C5yku.png)

## Code of CWE-73 in ovaa.apk

We use the [ovaa.apk](https://github.com/oversecured/ovaa) sample to explain the vulnerability code of CWE-73.

![image](https://imgur.com/gLJ6zWr.png)

## CWE-73 Detection Process Using Quark Script API

![image](https://imgur.com/zGjZHA1.png)

Let’s use the above APIs to show how Quark script finds this vulnerability.

First, we design a detection rule ``useLastPathSegmentAsFileName.json`` to spot behavior that uses the last path segment as the file name.

Second, we use the API ``methodInstance.getArguments()`` to get the argument for the file path and use ``quarkResultInstance.isHardcoded(argument)`` to check if the argument is hardcoded into the APK. If **No**, the argument is from external input.

Finally, we use Quark API ``quarkResultInstance.findMethodInCaller(callerMethod, targetMethod)`` to check if there are any APIs in the caller method for opening files. If **YES**, the APK performs file operations using external input as a path, which may cause CWE-73 vulnerability.

## Quark Script: CWE-73.py

![image](https://imgur.com/EHrcCPg.png)

```python
from quark.script import runQuarkAnalysis, Rule

SAMPLE_PATH = "ovaa.apk"
RULE_PATH = "useLastPathSegmentAsFileName.json"

OPEN_FILE_API = [
    "Landroid/os/ParcelFileDescriptor;",                   # Class name
    "open",                                                # Method name
    "(Ljava/io/File; I)Landroid/os/ParcelFileDescriptor;"  # Descriptor
]

ruleInstance = Rule(RULE_PATH)
quarkResult = runQuarkAnalysis(SAMPLE_PATH, ruleInstance)

for accessExternalDir in quarkResult.behaviorOccurList:
    filePath = accessExternalDir.secondAPI.getArguments()[2]

    if quarkResult.isHardcoded(filePath):
        continue

    caller = accessExternalDir.methodCaller
    result = quarkResult.findMethodInCaller(caller, OPEN_FILE_API)

    if result:
        print("CWE-73 is detected in method, ", caller.fullName)
```

## Quark Rule: useLastPathSegmentAsFileName.json

![image](https://imgur.com/JxBdde0.png)

```json
{
    "crime": "Use the last path segment as the file name",
    "permission": [],
    "api": [
        {
            "class": "Landroid/net/Uri;",
            "method": "getLastPathSegment",
            "descriptor": "()Ljava/lang/String;"
        },
        {
            "class": "Ljava/io/File;",
            "method": "<init>",
            "descriptor": "(Ljava/io/File;Ljava/lang/String;)V"
        }
    ],
    "score": 1,
    "label": []
}
```

## Quark Script Result

```
$ python CWE-73.py
CWE-73 is detected in method, Loversecured/ovaa/providers/TheftOverwriteProvider; openFile (Landroid/net/Uri; Ljava/lang/String;)Landroid/os/ParcelFileDescriptor;
```



# Detect CWE-78 in Android Application

This scenario seeks to find **Improper Neutralization of Special Elements used in an OS Command** in the APK file.

## CWE-78 Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')

We analyze the definition of CWE-78 and identify its characteristics.

See [CWE-78](https://cwe.mitre.org/data/definitions/78.html) for more details.

![image](https://imgur.com/HpMGGsO.png)

## Code of CWE-78 in Vuldroid.apk

We use the [Vuldroid.apk](https://github.com/jaiswalakshansh/Vuldroid) sample to explain the vulnerability code of CWE-78.

![image](https://imgur.com/7Tu0Y3H.png)

## CWE-78 Detection Process Using Quark Script API

![image](https://imgur.com/Hi7qGjw.png)

Let’s use the above APIs to show how the Quark script finds this vulnerability.

First, we design a detection rule `ExternalStringsCommands.json` to spot on behavior using external strings as commands.

Next, we use Quark API `behaviorInstance.getMethodsInArgs()` to get the methods that passed the external command.

Then we check if the method neutralizes any special elements in the argument.

If the neutralization is not complete, then it may cause CWE-78 vulnerability.

## Quark Script: CWE-78.py

![image](https://imgur.com/UpRWgGe.png)

```python
from quark.script import runQuarkAnalysis, Rule, findMethodInAPK

SAMPLE_PATH = "Vuldroid.apk"
RULE_PATH = "ExternalStringCommand.json"


STRING_MATCHING_API = set([
    ("Ljava/lang/String;", "contains", "(Ljava/lang/CharSequence)Z"),
    ("Ljava/lang/String;", "indexOf", "(I)I"),
    ("Ljava/lang/String;", "indexOf", "(Ljava/lang/String;)I"),
    ("Ljava/lang/String;", "matches", "(Ljava/lang/String;)Z"),
    (
        "Ljava/lang/String;",
        "replaceAll",
        "(Ljava/lang/String; Ljava/lang/String;)Ljava/lang/String;",
    ),
])

specialElementsPattern = r"[ ;|,>`]+"

ruleInstance = Rule(RULE_PATH)
quarkResult = runQuarkAnalysis(SAMPLE_PATH, ruleInstance)

for ExternalStringCommand in quarkResult.behaviorOccurList:

    methodCalled = set()
    caller = ExternalStringCommand.methodCaller

    for method in ExternalStringCommand.getMethodsInArgs():
        methodCalled.add(method.fullName)

    if methodCalled.intersection(STRING_MATCHING_API) and not ExternalStringCommand.hasString(specialElementsPattern):
        continue
    else:
        print(f"CWE-78 is detected in method, {caller.fullName}")
```
        
## Quark Rule: ExternalStringCommand.json

![image](https://imgur.com/eoV8hnZ.png)

```json
{
    "crime": "Using external strings as commands",
    "permission": [],
    "api": [
        {
            "class": "Landroid/content/Intent;",
            "method": "getStringExtra",
            "descriptor": "(Ljava/lang/String;)Ljava/lang/String"
        },
        {
            "class": "Ljava/lang/Runtime;",
            "method": "exec",
            "descriptor": "(Ljava/lang/String;)Ljava/lang/Process"
        }
    ],
    "score": 1,
    "label": []
}
```

## Quark Script Result

```
$ python3 CWE-78.py
CWE-78 is detected in method, Lcom/vuldroid/application/RootDetection; onCreate (Landroid/os/Bundle;)V
```